### PR TITLE
Add trailing dot to SSHFP record

### DIFF
--- a/check_sshfp
+++ b/check_sshfp
@@ -53,7 +53,7 @@ def output_sshfp_record(hostname, algorithm, key):
         if value == algorithm:
             algonum = number
             break
-    print("%s IN SSHFP %s 2 %s" % (hostname, algonum, hashlib.sha256(base64.b64decode(key)).hexdigest()))
+    print("%s. IN SSHFP %s 2 %s" % (hostname, algonum, hashlib.sha256(base64.b64decode(key)).hexdigest()))
 
 def check_sshfp_for_host(hostname):
     # Get the NS records so we can ask the auth server directly


### PR DESCRIPTION
The hostname passed to the plugin would normally be fully qualified, but without the trailing dot. When outputting the DNS record, it should use a trailing dot.